### PR TITLE
Switched the endpoint to use new 'https' requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Speechmatics.configure do |sm|
 
   # these are defaults
   sm.adapter    = :excon
-  sm.endpoint   = 'http://api.speechmatics.com/v1.0/'
+  sm.endpoint   = 'https://api.speechmatics.com/v1.0/'
   sm.user_agent = "Speechmatics Ruby Gem #{Speechmatics::VERSION}"
 end
 

--- a/lib/speechmatics/configuration.rb
+++ b/lib/speechmatics/configuration.rb
@@ -15,7 +15,7 @@ module Speechmatics
     DEFAULT_ADAPTER = :excon
 
     # The api endpoint to get REST
-    DEFAULT_ENDPOINT = 'http://api.speechmatics.com/v1.0/'.freeze
+    DEFAULT_ENDPOINT = 'https://api.speechmatics.com/v1.0/'.freeze
 
     # The value sent in the http header for 'User-Agent' if none is set
     DEFAULT_USER_AGENT = "Speechmatics Ruby Gem #{Speechmatics::VERSION}".freeze


### PR DESCRIPTION
We have just switched our api subdomain to target HTTPS.
HTTP will now just return a redirect message. I think small this is all that is required.
