### PR TITLE
get rid of audio endpoint, add changelog to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Speechmatics (https://speechmatics.com) provides an API for speech to text (http
 ## Installation
 
 Add this line to your application's Gemfile:
-  
+
     gem 'speechmatics'
 
 And then execute:
@@ -55,17 +55,22 @@ info = c.user.jobs.create(
 # retrieve job
 job = c.user.jobs.find(5678)
 
-# retrieve audio for a job
-audio = c.user.jobs(5678).audio
-# alt syntax
-audio = c.user.jobs.audio(5678)
-
 # retrieve trancript for a job
 trans = c.user.jobs(5678).transcript
 # alt syntax
 trans = c.user.jobs.transcript(5678)
 
 ```
+
+## Changes
+
+* 0.1.0 - 10/24/2014
+  Remove /user/$userid/jobs/$jobid/audio endpoint, no longer supported by speechmatics
+
+* 0.0.2 - 8/7/2014
+  Minor bug fix, treat integers/numbers as strings for params
+  Use mimemagic to determine content type (no more libmagic dependency; this works on heroku)
+  Switched the endpoint to use new 'https' requirement
 
 ## Contributing
 

--- a/lib/speechmatics/user/jobs.rb
+++ b/lib/speechmatics/user/jobs.rb
@@ -17,11 +17,6 @@ module Speechmatics
       request(:get, "#{base_path}/transcript")
     end
 
-    def audio(params={})
-      self.current_options = current_options.merge(args_to_options(params))
-      request(:get, "#{base_path}/audio")
-    end
-
     def set_mode(params={})
       params[:model] ||= 'en-US'
       params

--- a/lib/speechmatics/version.rb
+++ b/lib/speechmatics/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 module Speechmatics
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/test/user/jobs_test.rb
+++ b/test/user/jobs_test.rb
@@ -25,8 +25,7 @@ describe Speechmatics::Client do
           "notification" => "email",
           "size" => 1955132,
           "transcription" => "test.json",
-          "job_status" => "done",
-          "url" => "/user/1/jobs/2/audio"
+          "job_status" => "done"
         },
         {
           "created_at" => "Wed, 04 Dec 2013 16:08:33 GMT",
@@ -38,8 +37,7 @@ describe Speechmatics::Client do
           "notification" => "email",
           "size" => 6475938,
           "transcription" => nil,
-          "job_status" => "transcribing",
-          "url" => "/user/1/jobs/12/audio"
+          "job_status" => "transcribing"
         }
       ]
     }
@@ -55,17 +53,17 @@ describe Speechmatics::Client do
       }
       ],
       "words" => [
-      { 
+      {
         "duration" => "0.230",
         "name" => "Hello",
         "time" => "0.590"
       },
-      { 
+      {
         "duration" => "0.070",
         "name" => "World",
         "time" => "0.960"
       },
-      { 
+      {
         "duration" => "0.000",
         "name" => ".",
         "time" => "1.270"


### PR DESCRIPTION
Speechmatics will no longer support download of audio for a job, so removing the endpoint and docs for this.
(Makes sense - you uploaded the audio, you should have it - and this is not an audio storage service.)
