### PR TITLE
Eliminates Ruby warnings

### DIFF
--- a/lib/speechmatics/api.rb
+++ b/lib/speechmatics/api.rb
@@ -5,7 +5,7 @@ module Speechmatics
 
     include Connection
 
-    attr_reader *Speechmatics::Configuration.keys
+    attr_reader(*Speechmatics::Configuration.keys)
 
     attr_accessor :current_options
 
@@ -89,7 +89,7 @@ module Speechmatics
     end
 
     def args_to_options(args)
-      params =  if args.is_a?(String) || args.is_a?(Symbol) || args.is_a?(Numeric)
+      if args.is_a?(String) || args.is_a?(Symbol) || args.is_a?(Numeric)
         {"#{self.class.name.demodulize.downcase.singularize}_id" => args.to_s}
       elsif args.is_a?(Hash)
         args

--- a/lib/speechmatics/configuration.rb
+++ b/lib/speechmatics/configuration.rb
@@ -20,7 +20,7 @@ module Speechmatics
     # The value sent in the http header for 'User-Agent' if none is set
     DEFAULT_USER_AGENT = "Speechmatics Ruby Gem #{Speechmatics::VERSION}".freeze
 
-    attr_accessor *VALID_OPTIONS_KEYS
+    attr_accessor(*VALID_OPTIONS_KEYS)
 
     # Convenience method to allow for global setting of configuration options
     def configure

--- a/lib/speechmatics/user/jobs.rb
+++ b/lib/speechmatics/user/jobs.rb
@@ -37,7 +37,7 @@ module Speechmatics
     def attach_audio(params={})
       file_path = params[:data_file]
       raise "No file specified for new job, please provide a :data_file value" unless file_path
-      raise "No file exists at path '#{file_path}'" unless File.exists?(file_path)
+      raise "No file exists at path '#{file_path}'" unless File.exist?(file_path)
 
       content_type = params[:content_type] || MimeMagic.by_path(file_path).to_s
       raise "No content type specified for file, please provide a :content_type value" unless content_type


### PR DESCRIPTION
```
/Users/blangfeld/code/speechmatics/lib/speechmatics/configuration.rb:23: warning: `*' interpreted as argument prefix
/Users/blangfeld/code/speechmatics/lib/speechmatics/api.rb:8: warning: `*' interpreted as argument prefix
/Users/blangfeld/code/speechmatics/lib/speechmatics/api.rb:92: warning: assigned but unused variable - params
/Users/blangfeld/code/speechmatics/lib/speechmatics/user/jobs.rb:40: warning: File.exists? is a deprecated name, use File.exist? instead
```