### PR TITLE
Mixed requests

### DIFF
--- a/lib/speechmatics/connection.rb
+++ b/lib/speechmatics/connection.rb
@@ -30,12 +30,6 @@ module Speechmatics
     end
 
     def connection(options={})
-      if options[:allow_text]
-        allow_text = true
-        options.delete(:allow_text)
-      else
-        allow_text =false
-      end
       opts = merge_default_options(options)
 
       @conn ||= Faraday::Connection.new(opts) do |connection|
@@ -55,11 +49,7 @@ module Speechmatics
 
           connection.response :mashify
           connection.response :logger if ENV['DEBUG']
-          if allow_text
-            connection.response :json, :content_type => /\bjson$/
-          else
-            connection.response :json
-          end
+          connection.response :json, :content_type => /\bjson$/
           connection.adapter(*adapter)
         end
       end

--- a/lib/speechmatics/user/jobs.rb
+++ b/lib/speechmatics/user/jobs.rb
@@ -16,7 +16,7 @@ module Speechmatics
     def transcript(params={})
       self.current_options = current_options.merge(args_to_options(params))
       if params[:format] == "txt"
-        request(:get, "#{base_path}/transcript?format=txt", {:options => {:allow_text => true}})
+        request(:get, "#{base_path}/transcript?format=txt")
       else
         request(:get, "#{base_path}/transcript")
       end
@@ -24,7 +24,7 @@ module Speechmatics
 
     def alignment(params={})
       self.current_options = current_options.merge(args_to_options(params))
-      request(:get, "#{base_path}/alignment", {:options => {:allow_text => true}})
+      request(:get, "#{base_path}/alignment")
     end
 
     def set_mode(params={})

--- a/test/user/jobs_test.rb
+++ b/test/user/jobs_test.rb
@@ -128,4 +128,22 @@ describe Speechmatics::Client do
     a = jobs.alignment(job_id: 1)
     a.object.must_equal alignment
   end
+
+  it "can fetch txt transcription after fetching full" do
+    t1 = jobs.transcript(job_id: 1)
+    t1.speakers.count.must_equal 1
+    t1.words.count.must_equal 3
+
+    t2 = jobs.transcript(job_id: 1, format: "txt")
+    t2.object.must_equal "Hello World."
+  end
+
+  it "can fetch alignment after fetching transcription" do
+    t = jobs.transcript(job_id: 1)
+    t.speakers.count.must_equal 1
+    t.words.count.must_equal 3
+
+    a = jobs.alignment(job_id: 1)
+    a.object.must_equal alignment
+  end
 end

--- a/test/user/jobs_test.rb
+++ b/test/user/jobs_test.rb
@@ -72,12 +72,17 @@ describe Speechmatics::Client do
     }
   }
 
+  let(:alignment) {
+    "[00:00:00.1]	Hello world how are you?"
+  }
+
   let(:stubs) {
     Faraday::Adapter::Test::Stubs.new do |stub|
       stub.get('/v1.0/user/1/jobs/?auth_token=token') { [200, {}, list_jobs.to_json] }
       stub.post('/v1.0/user/1/jobs/?auth_token=token') { [200, {}, new_job.to_json] }
       stub.get('/v1.0/user/1/jobs/1/transcript?format=txt&auth_token=token') { [200, {}, "Hello World."] }
       stub.get('/v1.0/user/1/jobs/1/transcript?auth_token=token') { [200, {}, transcript.to_json] }
+      stub.get('/v1.0/user/1/jobs/1/alignment?auth_token=token') { [200, {}, alignment] }
     end
   }
 
@@ -117,5 +122,10 @@ describe Speechmatics::Client do
   it "gets transcript as text" do
     t = jobs.transcript(job_id: 1, format: "txt")
     t.object.must_equal "Hello World."
+  end
+
+  it "can align a text representation of the audio" do
+    a = jobs.alignment(job_id: 1)
+    a.object.must_equal alignment
   end
 end

--- a/test/user/jobs_test.rb
+++ b/test/user/jobs_test.rb
@@ -78,11 +78,11 @@ describe Speechmatics::Client do
 
   let(:stubs) {
     Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.get('/v1.0/user/1/jobs/?auth_token=token') { [200, {}, list_jobs.to_json] }
-      stub.post('/v1.0/user/1/jobs/?auth_token=token') { [200, {}, new_job.to_json] }
-      stub.get('/v1.0/user/1/jobs/1/transcript?format=txt&auth_token=token') { [200, {}, "Hello World."] }
-      stub.get('/v1.0/user/1/jobs/1/transcript?auth_token=token') { [200, {}, transcript.to_json] }
-      stub.get('/v1.0/user/1/jobs/1/alignment?auth_token=token') { [200, {}, alignment] }
+      stub.get('/v1.0/user/1/jobs/?auth_token=token') { [200, {"Content-Type" => "application/json"}, list_jobs.to_json] }
+      stub.post('/v1.0/user/1/jobs/?auth_token=token') { [200, {"Content-Type" => "application/json"}, new_job.to_json] }
+      stub.get('/v1.0/user/1/jobs/1/transcript?format=txt&auth_token=token') { [200, {"Content-Type" => "text/plain"}, "Hello World."] }
+      stub.get('/v1.0/user/1/jobs/1/transcript?auth_token=token') { [200, {"Content-Type" => "application/json"}, transcript.to_json] }
+      stub.get('/v1.0/user/1/jobs/1/alignment?auth_token=token') { [200, {"Content-Type" => "text/plain"}, alignment] }
     end
   }
 

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -7,8 +7,8 @@ describe Speechmatics::Client do
   let(:response) {
     {
       user: {
-         balance: 90, 
-         email: "demo@speechmatics.com", 
+         balance: 90,
+         email: "demo@speechmatics.com",
          id: 1
        }
     }
@@ -16,7 +16,7 @@ describe Speechmatics::Client do
 
   let(:stubs) {
     Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.get('/v1.0/user/1/?auth_token=token') { [200, {}, response.to_json] }
+      stub.get('/v1.0/user/1/?auth_token=token') { [200, {"Content-Type" => "application/json"}, response.to_json] }
     end
   }
 


### PR DESCRIPTION
When requesting textual transcriptions or alignments after a full transcription, the response is parsed as JSON incorrectly.